### PR TITLE
Updated action checkout and setup-node to v2

### DIFF
--- a/.github/ci-workflow.yml
+++ b/.github/ci-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: npm install and build webpack
         run: |
           npm install
@@ -25,9 +25,9 @@ jobs:
         node-version: [12.x, 14.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/download-artifact@master


### PR DESCRIPTION
Current actions version v1 results in error which at build step which does not allow one to complete step4.